### PR TITLE
Fix some potential snprintf(3) overflows

### DIFF
--- a/src/endpoints.c
+++ b/src/endpoints.c
@@ -798,17 +798,17 @@ char *ep_make_url(enum endpoint ep, const char * const params[], char *url)
 			break;
 
 		if (*token != '{')
-			len += snprintf(url + len, URL_LEN+1 - len, "/%s",
-					token);
+			snprintf(url + len, URL_LEN+1 - len, "/%s", token);
 		else if (strcmp(token, "{nino}") == 0)
-			len += snprintf(url + len, URL_LEN+1 - len, "/%s",
-					nino);
+			snprintf(url + len, URL_LEN+1 - len, "/%s", nino);
 		else if (strstr(token, "query_params"))
-			len += snprintf(url + len, URL_LEN+1 - len, "%s",
-					params[p] ? params[p++] : "");
+			snprintf(url + len, URL_LEN+1 - len, "%s",
+				 params[p] ? params[p++] : "");
 		else
-			len += snprintf(url + len, URL_LEN+1 - len, "/%s",
-					params[p++]);
+			snprintf(url + len, URL_LEN+1 - len, "/%s",
+				 params[p++]);
+
+		len = strlen(url);
 	}
 
 	free(string);

--- a/src/fph.c
+++ b/src/fph.c
@@ -336,8 +336,8 @@ static char *get_macaddrs(void *user_data __unused)
 		snprintf(mac, sizeof(mac), "%02x:%02x:%02x:%02x:%02x:%02x",
 			 ph[0], ph[1], ph[2], ph[3], ph[4], ph[5]);
 		encmac = mtd_percent_encode(mac, -1);
-		maclen += snprintf(buf + maclen, BUF_SZ - maclen, "%s,",
-				   encmac);
+		snprintf(buf + maclen, BUF_SZ - maclen, "%s,", encmac);
+		maclen = strlen(buf);
 		free(encmac);
 	}
 	buf[maclen - 1] = '\0';	/* trim trailing ',' */
@@ -490,7 +490,8 @@ static char *get_ipaddrs(void *user_data __unused)
 						sizeof(struct sockaddr_in6),
 			    ip, sizeof(ip), NULL, 0, NI_NUMERICHOST);
 		encip = mtd_percent_encode(ip, -1);
-		iplen += snprintf(buf + iplen, BUF_SZ - iplen, "%s,", encip);
+		snprintf(buf + iplen, BUF_SZ - iplen, "%s,", encip);
+		iplen = strlen(buf);
 		free(encip);
 	}
 	buf[iplen - 1] = '\0';	/* trim trailing ',' */

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -657,9 +657,11 @@ int mtd_init_auth(enum mtd_ep_api api, unsigned long scopes)
 	len = snprintf(url, sizeof(url),
 		       "%s/oauth/authorize?response_type=code&client_id=%s&scope=", mtd_ctx.api_url, client_id);
 	for (int i = 0; i < n; i++) {
-		if (scopes & scope_map[i].scope)
-			len += snprintf(url + len, sizeof(url) - len, "%s+",
-					scope_map[i].str);
+		if (scopes & scope_map[i].scope) {
+			snprintf(url + len, sizeof(url) - len, "%s+",
+				 scope_map[i].str);
+			len = strlen(url);
+		}
 	}
 	url[--len] = '\0';
 	snprintf(url + len, sizeof(url) - len,


### PR DESCRIPTION
It's quite common to use the following pattern

  len += snprintf(buf + len, sizeof(buf) - len, ...);

Ignoring the fact that snprintf can return -1, it can also return a
value larger than the buffer being written to as if the string is
truncated snprintf will return how many bytes _would_ have been written.

The simplest way to deal with this is to use strlen(3) on buf after each
snprintf to update the value of len.

Signed-off-by: Andrew Clayton <andrew@digital-domain.net>