### PR TITLE
Fix build against older glibc

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -17,10 +17,10 @@
 
 #include "mtd.h"
 #include "auth.h"
-#include "mtd-priv.h"
 #include "endpoints.h"
 #include "curler.h"
 #include "logger.h"
+#include "mtd-priv.h"
 
 extern __thread struct mtd_ctx mtd_ctx;
 

--- a/src/endpoints.c
+++ b/src/endpoints.c
@@ -14,11 +14,11 @@
 #include <stdarg.h>
 
 #include "mtd.h"
-#include "mtd-priv.h"
 #include "endpoints.h"
 #include "curler.h"
 #include "auth.h"
 #include "logger.h"
+#include "mtd-priv.h"
 
 #define MAX_PARAMS	7
 


### PR DESCRIPTION
When building on CentOS 7 with glibc 2.17 I got the following errors

  CC    auth.o
In file included from /usr/include/fcntl.h:77,
                 from platform.h:12,
                 from logger.h:20,
                 from auth.c:23:
/usr/include/bits/stat.h:106:31: error: expected identifier or ‘(’ before ‘[’ token
  106 |     __syscall_slong_t __unused[3];
      |                               ^
/usr/include/bits/stat.h:164:31: error: expected identifier or ‘(’ before ‘[’ token
  164 |     __syscall_slong_t __unused[3];
      |                               ^

  ...

  CC    endpoints.o
In file included from /usr/include/fcntl.h:77,
                 from platform.h:12,
                 from logger.h:20,
                 from endpoints.c:21:
/usr/include/bits/stat.h:106:31: error: expected identifier or ‘(’ before ‘[’ token
  106 |     __syscall_slong_t __unused[3];
      |                               ^
/usr/include/bits/stat.h:164:31: error: expected identifier or ‘(’ before ‘[’ token
  164 |     __syscall_slong_t __unused[3];
      |                               ^

This is because in mtd-priv.h we define __unused as an alias for
__attribute__((unused)) but now that we have platform.h which includes
fcntl.h, if that is included before mtd-priv.h we get the above
\\conflicts.

There may be neater ways to solve this, but the quick and simple fix is
to simply include mtd-priv.h last.