### PR TITLE
Enable FreeBSD build test on cirrus-ci.org

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,13 @@
+freebsd_instance:
+  image_family: freebsd-13-0
+  cpu: 1
+  memory: 1G
+
+task:
+  name: freebsd_13 (clang)
+  only_if: "changesInclude('.cirrus.yml', 'Makefile', 'src/**')"
+  install_script: pkg install -y gmake jansson curl e2fsprogs-libuuid
+  # We don't have a full repository checkout here so fudge
+  # the GIT_VERSION (libmtdac version) as it's not actually
+  # important what it is just to test the build.
+  script: CFLAGS=-Werror gmake CC=clang GIT_VERSION=\\\"v0.0.0\\\" V=1


### PR DESCRIPTION
This runs in a FreeBSD 13.0 VM and uses clang.