### PR TITLE
cirrus-ci: Use 'skip' rather than 'only-if'

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ freebsd_instance:
 
 task:
   name: freebsd_13 (clang)
-  only_if: "changesInclude('.cirrus.yml', 'Makefile', 'src/**')"
+  skip: "!changesInclude('.cirrus.yml', 'Makefile', 'src/**')"
   install_script: pkg install -y gmake jansson curl e2fsprogs-libuuid
   # We don't have a full repository checkout here so fudge
   # the GIT_VERSION (libmtdac version) as it's not actually


### PR DESCRIPTION
It's not very clear from the docs[0] but maybe 'skip' is what we really
want to skip running the build if there isn't any code changes.

[0]: https://cirrus-ci.org/guide/writing-tasks/#conditional-task-execution
