### PR TITLE
github/workflows: Add a white space checker

### DIFF
--- a/.github/workflows/check-whitespace.yaml
+++ b/.github/workflows/check-whitespace.yaml
@@ -1,0 +1,49 @@
+name: check-whitespace
+
+# Get the repo with the commits(+1) in the series.
+# Process `git log --check` output to extract just the check errors.
+# Add a comment to the pull request with the check errors.
+
+on:
+  pull_request:
+    types: [ opened, synchronize ]
+
+jobs:
+  check-whitespace:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: git log --check
+      id: check_out
+      run: |
+        log=
+        commit=
+        while read dash etc
+        do
+          case "${dash}" in
+          "---")
+            commit="${etc}"
+            ;;
+          "")
+            ;;
+          *)
+            if test -n "${commit}"
+            then
+              log="${log}\n${commit}"
+              echo ""
+              echo "--- ${commit}"
+            fi
+            commit=
+            log="${log}\n${dash} ${etc}"
+            echo "${dash} ${etc}"
+            ;;
+          esac
+        done <<< $(git log --check --pretty=format:"--- %h %s" ${{github.event.pull_request.base.sha}}..)
+
+        if test -n "${log}"
+        then
+          exit 2
+        fi


### PR DESCRIPTION
Add a GitHub workflow to check for white space issues in pull-requests.

This comes from the git[0] project.

[0]: https://git.kernel.org/pub/scm/git/git.git/tree/.github/workflows/check-whitespace.yml