### PR TITLE
Enable linking with -zdefs on FreeBSD

### DIFF
--- a/.ci/freebsd-clang-build.sh
+++ b/.ci/freebsd-clang-build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# This script is for CI environments and is to get around the
+# problem of linking with -zdefs on FreeBSD and the environ
+# variable (which we use in libmtdac) which unlike in Linux/glibc
+# is _not_ defined in libc but in /usr/lib/crt1.o which is only
+# linked into executables.
+#
+# That means linking libmtdac always produces
+#
+#   ld: warning: undefined symbol: environ
+#
+# Seeing as there is no way currently (that I could find) to tell
+# the linker to not warn about certain symbols, we use this script
+# to wrap the compile/linking process, look for undefined symbols,
+# if we get no undefined symbols or only environ, return 0 (success)
+# if we get any other undefined symbols return 1 (failure).
+
+error=
+
+while read line
+do
+	if [[ $line =~ "undefined symbol:" ]]; then
+		if [[ $line =~ " environ" ]]; then
+			echo "  IGNORE undefined symbol: environ"
+		else
+			error=1
+		fi
+	fi
+done <<<$(CFLAGS=-Werror gmake CC=clang GIT_VERSION=\\\"v0.0.0\\\" V=1 -C src/ 3>&1 1>&2 2>&3 | tee /dev/stderr)
+
+# The crazy command above basically displays the make output
+# to the console while sending stderr through the while loop.
+# See https://sebthom.de/158-bash-capturing-stderr-variable/
+
+# If $error is set, we got at least one undefined symbol that
+# wasn't 'environ' so we need to fail the build.
+if test -n "$error"
+then
+	exit 1
+fi
+
+exit 0

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,8 +6,8 @@ freebsd_instance:
 task:
   name: freebsd_13 (clang)
   skip: "!changesInclude('.cirrus.yml', 'Makefile', 'src/**')"
-  install_script: pkg install -y gmake jansson curl e2fsprogs-libuuid
+  install_script: pkg install -y bash gmake jansson curl e2fsprogs-libuuid
   # We don't have a full repository checkout here so fudge
   # the GIT_VERSION (libmtdac version) as it's not actually
   # important what it is just to test the build.
-  script: CFLAGS=-Werror gmake CC=clang GIT_VERSION=\\\"v0.0.0\\\" V=1
+  script: .ci/freebsd-clang-build.sh

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ CFLAGS += -Wall -Wextra -Wdeclaration-after-statement -Wvla -std=gnu99 -g -O2 \
 	  -Wp,-D_FORTIFY_SOURCE=2 --param=ssp-buffer-size=4 -fstack-protector \
 	  -fPIC -fexceptions -fvisibility=hidden -I../include/libmtdac \
 	  -DLIBNAME=\"$(LIBNAME)\" -DGIT_VERSION=${GIT_VERSION} -pipe
-LDFLAGS = -shared -Wl,-z,now,-z,relro,--as-needed
+LDFLAGS = -shared -Wl,-z,now,-z,relro,-z,defs,--as-needed
 LIBS	= -lcurl -ljansson
 POSTCOMPILE = @mv -f $(DEPDIR)/$*.Td $(DEPDIR)/$*.d && touch $@
 
@@ -24,11 +24,11 @@ ifeq ($(CC),clang)
 endif
 
 UNAME_S := $(shell uname -s | tr A-Z a-z)
-ifeq ($(UNAME_S),linux)
-        # On Linux we link with -z defs, on FreeBSD this gives
-        # a linker error about undefined symbol: environ
-        LDFLAGS := $(LDFLAGS),-z,defs
-else ifeq ($(UNAME_S),freebsd)
+ifeq ($(UNAME_S),freebsd)
+        # Don't fail the build on unresolved symbols, environ is _always_
+        # undefined. In Ci we warp the build in .ci/freebsd-clang-build.sh
+        # which will decide if the build fails or not.
+        LDFLAGS := $(LDFLAGS),--warn-unresolved-symbols
         CFLAGS  += -I/usr/local/include
         LIBS    := -L/usr/local/lib $(LIBS) -luuid
 endif


### PR DESCRIPTION
We couldn't link with -zdefs under FreeBSD due to the environ variable
(which we use in libmtdac) which unlike in Linux/glibc is _not_ defined
in libc but in /usr/lib/crt1.o which is only linked into executables.

That means linking libmtdac always produces

  ld: warning: undefined symbol: environ

However -zdefs is really useful for finding legitimate issues.

So what we do on FreeBSD is link with -zdefs as we do on Linux, but turn
any undefined symbols errors into warnings so the build doesn't fail.

For CI environments we do want the build to fail for any undefined
symbols that aren't 'environ'.

To enable that we create a script to wrap the build process on FreeBSD.
This script looks for undefined symbols, if we get no undefined symbols
or only environ, return 0 (success) if we get any other undefined
symbols return 1 (failure).