### PR TITLE
github/workflows: Replace CentOS 8 with CentOS Stream

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -37,12 +37,12 @@ jobs:
         # number is not actually important to just test the build.
         run: CFLAGS=-Werror make GIT_VERSION=\\\"v0.0.0\\\" V=1
 
-  # CentOS 8 / glibc 2.28 / gcc 8.4.1
-  centos_8:
+  # Rocky Linux 8 (RHEL clone) / glibc 2.28 / gcc 8.5.0
+  rocky-linux-8:
     runs-on: ubuntu-latest
 
     container:
-      image: centos:8
+      image: rockylinux:8
 
     steps:
       - name: Install tools/deps


### PR DESCRIPTION
CentOS 8 went EOL December 31st 2021 and this workflow now fails with

  Run yum -y install git gcc make jansson-devel libcurl-devel
  CentOS Linux 8 - AppStream                      192  B/s |  38  B     00:00
  Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist

CentOS Stream is a continuously delivered distro that tracks just ahead
of Red Hat Enterprise Linux (RHEL) development, positioned as a
midstream between Fedora Linux and RHEL.
