### PR TITLE
curler.c: Initialise err in set_headers()

### DIFF
--- a/src/curler.c
+++ b/src/curler.c
@@ -380,7 +380,7 @@ static int curl_perform(struct curl_ctx *ctx)
 static int set_headers(struct curl_ctx *ctx)
 {
 	int ret = MTD_ERR_NONE;
-	int err;
+	int err = 0;
 	const char * const *hdrs;
 
 	if (!strstr(ctx->url, "/oauth/token")) {


### PR DESCRIPTION
When the LGTM[0] service is building libmtdac, it is showing the
following compiler warning

[2022-03-31 02:08:00] [build-stderr] curler.c:402:5: warning: ‘err’ may be used uninitialized in this function [-Wmaybe-uninitialized]
[2022-03-31 02:08:00] [build-stderr]   402 |  if (err)
[2022-03-31 02:08:00] [build-stderr]       |     ^
[2022-03-31 02:08:00] [build-stderr] curler.c:383:6: note: ‘err’ was declared here
[2022-03-31 02:08:00] [build-stderr]   383 |  int err;
[2022-03-31 02:08:00] [build-stderr]       |      ^~~

Now, I don't see this under GCC 11.2, 10.3, 10.2, 8.5, 8.3, 4.8 or clang
13, 12, 11, 7 under a variety of OS's, Fedora, CentOS, Debian, FreeBSD.

LGTM says it uses latest Ubuntu and it seems to be using

[2022-03-31 04:46:11] [build-stdout] Unpacking gcc-10-cross-base (10.3.0-1ubuntu1~20.04cross1) ...
[2022-03-31 04:46:11] [build-stdout] Selecting previously unselected package libgcc-s1-amd64-cross.
[2022-03-31 04:46:11] [build-stdout] Preparing to unpack .../libgcc-s1-amd64-cross_10.3.0-1ubuntu1~20.04cross1_all.deb ...
[2022-03-31 04:46:11] [build-stdout] Unpacking libgcc-s1-amd64-cross (10.3.0-1ubuntu1~20.04cross1) ...
[2022-03-31 04:46:11] [build-stdout] Setting up gcc-10-cross-base (10.3.0-1ubuntu1~20.04cross1) ...
[2022-03-31 04:46:11] [build-stdout] Setting up libgcc-s1-amd64-cross (10.3.0-1ubuntu1~20.04cross1) ...

Looking at the code in question, the only way that err can be used
uninitialised is if

  ctx->url contains "/oauth/token" and
  ctx->content_type == CONTENT_TYPE_NONE

which currently is not a possible combination.

However initialising err to 0 does no harm and will guard against future
changes that may make the above no longer true.

[0]: https://lgtm.com/
