### PR TITLE
mtd-il: Update to version 3.0 of the API

### DIFF
--- a/API.md
+++ b/API.md
@@ -904,8 +904,7 @@ int mtd_il_lc_update_loss_type(const struct mtd_dsrc_ctx *dsctx,
 
 ```C
 int mtd_il_lc_update_loss_order(const struct mtd_dsrc_ctx *dsctx,
-                                const char *query_string,
-                                char **buf);
+                                const char *tax_year, char **buf);
 ```
 
 

--- a/include/libmtdac/mtd-il.h
+++ b/include/libmtdac/mtd-il.h
@@ -3,7 +3,7 @@
 /*
  * mtd-il.h - Make Tax Digital - Individual Loses API
  *
- * Copyright (C) 2020		Andrew Clayton <andrew@digital-domain.net>
+ * Copyright (C) 2020, 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
 #ifndef _MTD_IL_H_
@@ -18,7 +18,7 @@ extern "C" {
 #pragma GCC visibility push(default)
 
 extern int mtd_il_lc_update_loss_order(const struct mtd_dsrc_ctx *dsctx,
-				       const char *query_string, char **buf);
+				       const char *tax_year, char **buf);
 extern int mtd_il_lc_update_loss_type(const struct mtd_dsrc_ctx *dsctx,
 				      const char *cid, char **buf);
 extern int mtd_il_lc_delete_loss(const char *cid, char **buf);

--- a/man/man3/libmtdac_mtd-il.h.3
+++ b/man/man3/libmtdac_mtd-il.h.3
@@ -1,4 +1,4 @@
-.TH libmtdac_mtd-il.h 3 "June 1, 2020" "libmtdac 0.9.0" "libmtdac_mtd-il.h"
+.TH libmtdac_mtd-il.h 3 "Aptil 4, 2022" "libmtdac 0.60.0" "libmtdac_mtd-il.h"
 
 .SH NAME
 libmtdac_mtd-il.h \- Make Tax Digital \- Individual Loses API
@@ -81,7 +81,8 @@ Individual Loses API.
 .BR mtd_il_lc_update_loss_type (3)
 .RE
 
-.BI "int mtd_il_lc_update_loss_order(const char *" src_file ", char **" buf ");"
+.BI "int mtd_il_lc_update_loss_order(const struct mtd_dsrc_ctx *" dsctx ",
+.BI "                                const char *" tax_year ", char **" buf );
 
 .RS +4
 .BR mtd_il_lc_update_loss_order (3)

--- a/man/man3/mtd_il_bf_create_loss.3
+++ b/man/man3/mtd_il_bf_create_loss.3
@@ -1,4 +1,4 @@
-.TH MTD_IL_BF_CREATE_LOSS 3 "June 7, 2020" "" "libmtdac"
+.TH MTD_IL_BF_CREATE_LOSS 3 "April 3, 2022" "" "libmtdac"
 
 .SH NAME
 
@@ -15,14 +15,62 @@ mtd_il_bf_create_loss \- create individual brought forward loss
 .SH DESCRIPTION
 
 This function allows developers to create a new brought forward loss which can
-be submitted against Self-employment, Self-employment class 4, UK FHL property
-and UK other (Non-FHL) property for the tax year prior to joining MTD.
+be submitted against self-employment, self-employment class 4, UK Furnished
+Holiday Let (FHL) property, UK other (Non-FHL) property, foreign property FHL
+in the European Economic Area (EEA) and foreign property for the tax year
+prior to joining MTD.
 
 .TP 4
 .B dsctx
 This points to either a buffer, filename, file pointer or file descriptor that
 contains the JSON payload to be sent. See
 .BR mtd_dsrc_ctx (3)
+.PP
+.RS 4
+Scenario: Self-Employment Request
+.PP
+.RE
+.RS 8
+.EX
+{
+    "taxYearBroughtForwardFrom": "2020-21",
+    "businessId": "XBIS12345678910",
+    "typeOfLoss": "self-employment",
+    "lossAmount": 5001.99
+}
+.EE
+.RE
+.PP
+.RE
+.RS 4
+Scenario: UK FHL Property Request
+.PP
+.RE
+.RS 8
+.EX
+{
+    "taxYearBroughtForwardFrom": "2020-21",
+    "businessId": "XPIS12345678910",
+    "typeOfLoss": "uk-property-fhl",
+    "lossAmount": 500.99
+}
+.EE
+.RE
+.PP
+.RS 4
+Scenario: Foreign Property Request
+.PP
+.RE
+.RS 8
+.EX
+{
+    "taxYearBroughtForwardFrom": "2020-21",
+    "businessId": "XFIS12345678910",
+    "typeOfLoss": "foreign-property",
+    "lossAmount": 5000.99
+}
+.EE
+.RE
 
 .PP
 

--- a/man/man3/mtd_il_bf_list_loses.3
+++ b/man/man3/mtd_il_bf_list_loses.3
@@ -1,4 +1,4 @@
-.TH MTD_IL_BF_LIST_LOSES 3 "August 23, 2021" "" "libmtdac"
+.TH MTD_IL_BF_LIST_LOSES 3 "April 3, 2022" "" "libmtdac"
 
 .SH NAME
 
@@ -20,7 +20,7 @@ losses which have incurred before joining MTD.
 This is optional and is of the form
 .PP
 .RS 8
-[?[businessId=XNISNNNNNNNNNNN][&[taxYear=YYYY-YY][&[typeOfLoss={self-employment,uk-property-fhl,uk-property-non-fhl}]]]]
+[?[businessId=XNISNNNNNNNNNNN][&[taxYearBroughtForwardFrom=YYYY-YY][&[typeOfLoss={self-employment,uk-property-fhl,uk-property-non-fhl,foreign-property-fhl-eea,foreign-property}]]]]
 .RE
 
 .RS 4
@@ -32,9 +32,27 @@ This is optional and is of the form
 .RE
 
 .RS 4
-\fBtaxYear\fP is an optional tax year.
+\fBtaxYearBroughtForwardFrom\fP is an optional tax year in the form
+.RE
 
-\fBtypeOfLoss\fP is optional and is \fBone\fP of the above shown values.
+.RS 8
+YYYY-YY
+.RE
+
+.RS 4
+\fBtypeOfLoss\fP is optional and is \fBone\fP of the following values
+.RE
+
+.RS 8
+self-employment
+.br
+uk-property-fhl
+.br
+uk-property-non-fhl
+.br
+foreign-property-fhl-eea
+.br
+foreign-property
 .RE
 
 .TP

--- a/man/man3/mtd_il_lc_create_loss.3
+++ b/man/man3/mtd_il_lc_create_loss.3
@@ -23,6 +23,53 @@ Statement.
 This points to either a buffer, filename, file pointer or file descriptor that
 contains the JSON payload to be sent. See
 .BR mtd_dsrc_ctx (3)
+.PP
+.RS 4
+Scenario: Self-Employment Claim Request
+.PP
+.RE
+.RS 8
+.EX
+{
+    "businessId": "XBIS12356589871",
+    "typeOfLoss": "self-employment",
+    "typeOfClaim": "carry-forward",
+    "taxYearClaimedFor": "2019-20"
+}
+.EE
+.RE
+
+.PP
+.RS 4
+Scenario: UK Property Claim Request
+.PP
+.RE
+.RS 8
+.EX
+{
+    "businessId": "XPIS12356589871",
+    "typeOfLoss": "uk-property-non-fhl",
+    "typeOfClaim": "carry-sideways",
+    "taxYearClaimedFor": "2019-20"
+}
+.EE
+.RE
+
+.PP
+.RS 4
+Scenario: Foreign Property Claim Request
+.PP
+.RE
+.RS 8
+.EX
+{
+    "businessId": "XFIS12356589871",
+    "typeOfLoss": "foreign-property",
+    "typeOfClaim": "carry-sideways",
+    "taxYearClaimedFor": "2019-20"
+}
+.EE
+.RE
 
 .PP
 

--- a/man/man3/mtd_il_lc_list_loses.3
+++ b/man/man3/mtd_il_lc_list_loses.3
@@ -1,4 +1,4 @@
-.TH MTD_IL_LC_LIST_LOSES 3 "August 23, 2021" "" "libmtdac"
+.TH MTD_IL_LC_LIST_LOSES 3 "April 4, 2022" "" "libmtdac"
 
 .SH NAME
 
@@ -19,7 +19,7 @@ This function allows developers to retrieve a list of all loss claims.
 This is optional and is of the form
 .PP
 .RS 8
-[?[businessId=XNISNNNNNNNNNNN][&[taxYear=YYYY-YY][&[typeOfLoss={self-employment,uk-property-fhl,uk-property-non-fhl}][&[claimType=carry-sideways]]]]]
+[?[businessId=XNISNNNNNNNNNNN][&[taxYearClaimedFor=YYYY-YY][&[typeOfLoss={self-employment,uk-property-non-fhl,foreign-property}][&[typeOfClaim=carry-sideways]]]]]
 .RE
 
 .RS 4
@@ -31,11 +31,27 @@ This is optional and is of the form
 .RE
 
 .RS 4
-\fBtaxYear\fP is an optional tax year.
+\fBtaxYearClaimedFor\fP is an optional tax year in the form
+.RE
 
-\fBtypeOfLoss\fP is optional and is \fBone\fP of the above shown values.
+.RS 8
+YYYY-YY
+.RE
 
-\fBclaimType\fP is optional and takes the value \fBcarry-sideways\fP
+.RS 4
+\fBtypeOfLoss\fP is optional and is \fBone\fP of the following values
+.RE
+
+.RS 8
+self-employment
+.br
+uk-property-non-fhl
+.br
+foreign-property
+.RE
+
+.RE 4
+\fBtypeOfClaim\fP is optional and takes the value \fBcarry-sideways\fP
 .RE
 
 .TP

--- a/man/man3/mtd_il_lc_update_loss_order.3
+++ b/man/man3/mtd_il_lc_update_loss_order.3
@@ -1,4 +1,4 @@
-.TH MTD_IL_LC_UPDATE_LOSS_ORDER 3 "June 7, 2020" "" "libmtdac"
+.TH MTD_IL_LC_UPDATE_LOSS_ORDER 3 "April 4, 2022" "" "libmtdac"
 
 .SH NAME
 
@@ -10,7 +10,7 @@ mtd_il_lc_update_loss_order \- update individual loss claims order
 .PP
 .nf
 .BI "int mtd_il_lc_update_loss_order(const struct mtd_dsrc_ctx *" dsctx ",
-.BI "                                const char *" query_string ", char **" buf );
+.BI "                                const char *" tax_year ", char **" buf );
 .fi
 
 .SH DESCRIPTION
@@ -34,18 +34,18 @@ E.g
 .RS 8
 .EX
 {
-    "claimType": "carry-sideways",
+    "typeOfClaim": "carry-sideways",
     "listOfLossClaims": [
         {
-            "id": "1234567890ABCDE",
+            "claimId": "1234567890ABCDE",
             "sequence": 2
         },
         {
-            "id": "1234567890ABDE0",
+            "claimId": "1234567890ABDE0",
             "sequence": 3
         },
         {
-            "id": "1234567890ABEF1",
+            "claimId": "1234567890ABEF1",
             "sequence": 1
         }
     ]
@@ -56,15 +56,13 @@ E.g
 .PP
 
 .TP
-.B query_string
+.B tax_year
 .RS 4
-This is an optional (can be NULL) query string that specifies the tax year to
-operate on. It is of the following form
-
+This is the taxYearClaimedFor and is in the form
 .RE
 
 .RS 8
-?taxYear=YYYY-YY
+YYYY-YY
 .RE
 
 .TP

--- a/man/man3/mtd_il_lc_update_loss_type.3
+++ b/man/man3/mtd_il_lc_update_loss_type.3
@@ -1,4 +1,4 @@
-.TH MTD_IL_LC_UPDATE_LOSS_TYPE 3 "June 7, 2020" "" "libmtdac"
+.TH MTD_IL_LC_UPDATE_LOSS_TYPE 3 "April 4, 2022" "" "libmtdac"
 
 .SH NAME
 
@@ -23,6 +23,14 @@ loss claim.
 This points to either a buffer, filename, file pointer or file descriptor that
 contains the JSON payload to be sent. See
 .BR mtd_dsrc_ctx (3)
+.PP
+.RS 8
+.EX
+{
+    "typeOfClaim": "carry-forward"
+}
+.EE
+.RE
 
 .PP
 

--- a/src/endpoints.c
+++ b/src/endpoints.c
@@ -285,7 +285,7 @@ static const struct _endpoint {
 		.api	= MTD_EP_API_ITSA
 	},
 	[IL_LC_UPDATE_LOSS_ORDER] = {
-		.tmpl	= "/individuals/losses/{nino}/loss-claims/order/{optional_query_params}",
+		.tmpl	= "/individuals/losses/{nino}/loss-claims/order/{taxYearClaimedFor}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
 		.authz	= AUTHZ_USER,

--- a/src/mtd-ep-il.c
+++ b/src/mtd-ep-il.c
@@ -3,7 +3,7 @@
 /*
  * mtd-ep-il.c - Make Tax Digital - Individual Loses API
  *
- * Copyright (C) 2020 - 2021	Andrew Clayton <andrew@digital-domain.net>
+ * Copyright (C) 2020 - 2022	Andrew Clayton <andrew@digital-domain.net>
  */
 
 #include <stddef.h>
@@ -11,22 +11,18 @@
 #include "mtd-il.h"		/* for default (public) visibility */
 #include "endpoints.h"
 
-#define VERSION		"2.0"
+#define VERSION		"3.0"
 #define API_VER		"Accept: application/vnd.hmrc." VERSION "+json"
 
 /*
  * [PUT ]
- * /individuals/losses/{nino}/loss-claims/order
- *
- * Optional query string:
- *
- *      ?taxYear=YYYY-YY
+ * /individuals/losses/{nino}/loss-claims/order/{taxYearClaimedFor}
  */
 int mtd_il_lc_update_loss_order(const struct mtd_dsrc_ctx *dsctx,
-				const char *query_string, char **buf)
+				const char *tax_year, char **buf)
 {
 	return do_ep(IL_LC_UPDATE_LOSS_ORDER, API_VER,
-		     dsctx, buf, query_string, (char *)NULL);
+		     dsctx, buf, tax_year, (char *)NULL);
 }
 
 /*
@@ -76,9 +72,9 @@ int mtd_il_lc_create_loss(const struct mtd_dsrc_ctx *dsctx, char **buf)
  *
  * Optional query string:
  *
- *	?businessId=&taxYear=YYYY-YY&typeOfLoss=&claimType=carry-sideways
+ *	?businessId=&taxYearClaimedFor=YYYY-YY&typeOfLoss=&typeOfClaim=carry-sideways
  *
- *	typeOfLoss={self-employment,uk-property-fhl,uk-property-non-fhl}
+ *	typeOfLoss={self-employment,uk-property-non-fhl,foreign-property}
  */
 int mtd_il_lc_list_loses(const char *query_string, char **buf)
 {
@@ -133,9 +129,10 @@ int mtd_il_bf_create_loss(const struct mtd_dsrc_ctx *dsctx, char **buf)
  *
  * Optional query string:
  *
- *	?businessId=&taxYear=YYYY-YY&typeOfLoss=
+ *	?businessId=&taxYearBroughtForwardFrom=YYYY-YY&typeOfLoss=
  *
- *	typeOfLoss={self-employment,uk-property-fhl,uk-property-non-fhl}
+ *	typeOfLoss={self-employment,uk-property-fhl,uk-property-non-fhl,
+ *		    foreign-property-fhl-eea,foreign-property}
  */
 int mtd_il_bf_list_loses(const char *query_string, char **buf)
 {


### PR DESCRIPTION
Only some minor changes

  - taxYear -> taxYearClaimedFor in query strings
  - changes to the possible value of the typeOfLoss query_string value
  - mtd_il_lc_update_loss_order() no longer takes a query_string
    parameter, but instead takes a tax_year representing
    taxYearClaimedFor
