### PR TITLE
github/workflows: Fix build by setting git safe.directory

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -53,7 +53,9 @@ jobs:
           fetch-depth: "0"
 
       - name: make
-        run: CFLAGS=-Werror make V=1
+        run: |
+          git config --global --add safe.directory /__w/libmtdac/libmtdac
+          CFLAGS=-Werror make V=1
 
   # Debian 11 / glibc 2.31 / gcc 10.2
   debian_11:
@@ -73,7 +75,9 @@ jobs:
           fetch-depth: "0"
 
       - name: make
-        run: CFLAGS=-Werror make V=1
+        run: |
+          git config --global --add safe.directory /__w/libmtdac/libmtdac
+          CFLAGS=-Werror make V=1
 
   # Alpine Linux with musl libc and GCC
   alpine:
@@ -91,7 +95,9 @@ jobs:
           fetch-depth: "0"
 
       - name: make
-        run: CFLAGS=-Werror make V=1
+        run: |
+          git config --global --add safe.directory /__w/libmtdac/libmtdac
+          CFLAGS=-Werror make V=1
 
   # Fedora 34 / glibc 2.33 / gcc 11.2 / clang 12.0
   # Fedora 35 / glibc 2.34 / gcc 11.2 / clang 13.0
@@ -116,4 +122,6 @@ jobs:
           fetch-depth: "0"
 
       - name: make CC=${{ matrix.compiler }}
-        run: CFLAGS=-Werror make CC=${{ matrix.compiler }} V=1
+        run: |
+          git config --global --add safe.directory /__w/libmtdac/libmtdac
+          CFLAGS=-Werror make CC=${{ matrix.compiler }} V=1


### PR DESCRIPTION
Git recently made some updates[0][1] fixing a CVE.

This has unfortunately caused the build on Alpine to fail with the
following

gcc -MT .objs/curler.o -MMD -MP -MF .d/curler.o.Td -Werror -Wall -Wextra -Wdeclaration-after-statement -Wvla -Wmissing-prototypes -Wstrict-prototypes -Wold-style-definition -std=gnu99 -g -O2 -Wp,-D_FORTIFY_SOURCE=2 --param=ssp-buffer-size=4 -fno-common -fstack-protector -fPIC -fexceptions -fvisibility=hidden -I../include/libmtdac -DLIBNAME=\"libmtdac\" -DGIT_VERSION=\"\" -pipe -c -o .objs/curler.o curler.c
curler.c: In function 'do_curl':
curler.c:292:2: error: offset '1' outside bounds of constant string [-Werror=array-bounds]
  292 |  snprintf(ua, 1024, "%s %d.%d.%d (%s) / (libcurl/%s)",
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  293 |    LIBNAME, LIBMTDAC_MAJOR_VERSION, LIBMTDAC_MINOR_VERSION,
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  294 |    LIBMTDAC_MICRO_VERSION, GIT_VERSION + 1, verinfo->version);
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

The GIT_VERSION is empty! and just above that we have

  fatal: unsafe repository ('/__w/libmtdac/libmtdac' is owned by someone else)
  To add an exception for this directory, call:
  	git config --global --add safe.directory /__w/libmtdac/libmtdac

This is the result of trying to run

  git describe --long --dirty

GitHub have made some changes to the actions/checkout@...[2] to
workaround this, however this doesn't persist beyond the initial
checkout stage[3] and so the git command fails in the Makefile where we
try and get the version.

To fix this we need to set the safe.directory ourselves from the make
action. This updates all the builds as it won't harm older gits that
don't have this issue and don't know about safe.directory (they'll just
ignore that setting).

[0]: https://lore.kernel.org/git/xmqqv8veb5i6.fsf@gitster.g/
[1]: https://github.blog/2022-04-12-git-security-vulnerability-announced/
[2]: https://github.com/actions/checkout/pull/762
[3]: https://github.com/actions/checkout/issues/766
