### PR TITLE
A couple of misc updates

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$(@F).Td
 CC	= gcc
 CFLAGS += -Wall -Wextra -Wdeclaration-after-statement -Wvla \
 	  -Wmissing-prototypes -Wstrict-prototypes -Wold-style-definition \
-	  -std=gnu99 -g -O2 -Wp,-D_FORTIFY_SOURCE=2 --param=ssp-buffer-size=4 \
+	  -std=gnu11 -g -O2 -Wp,-D_FORTIFY_SOURCE=2 --param=ssp-buffer-size=4 \
 	  -fno-common -fstack-protector -fPIC -fexceptions \
 	  -fvisibility=hidden -I../include/libmtdac \
 	  -DLIBNAME=\"$(LIBNAME)\" -DGIT_VERSION=${GIT_VERSION} -pipe

--- a/src/endpoints.c
+++ b/src/endpoints.c
@@ -637,7 +637,7 @@ int do_ep(enum endpoint ep, const char *api_ver,
 	  const struct mtd_dsrc_ctx *dsctx, char **buf, ...)
 {
 	va_list ap;
-	struct curl_ctx ctx = { 0 };
+	struct curl_ctx ctx = {};
 	const char *params[MAX_PARAMS] = { NULL };
 	int i = 0;
 


### PR DESCRIPTION
* Use {} instead of {0} to initialise the ctx structure in do_ep()
* Update the standard we compile with to gnu11 (C11 + GNU extensions)