### PR TITLE
Reduce duplication in endpoints[]

### DIFF
--- a/include/libmtdac/mtd.h
+++ b/include/libmtdac/mtd.h
@@ -222,8 +222,10 @@ enum mtd_scope {
 };
 
 enum mtd_api_scope {
-	MTD_API_SCOPE_ITSA		= 0x0,
-	MTD_API_SCOPE_VAT		= 0x1,
+	MTD_API_SCOPE_UNSET		= 0x0,
+
+	MTD_API_SCOPE_ITSA		= 0x1,
+	MTD_API_SCOPE_VAT		= 0x2,
 
 	/*
 	 * Special value to tell we are adding more API

--- a/src/api_endpoints.h
+++ b/src/api_endpoints.h
@@ -15,7 +15,8 @@
 #include "curler.h"
 
 enum oauth_authz {
-	AUTHZ_NONE = 0,
+	AUTHZ_UNSET = 0,
+	AUTHZ_NONE,
 	AUTHZ_APPLICATION,
 	AUTHZ_USER,
 };
@@ -36,6 +37,64 @@ enum ep_api {
 	EP_API_TEST_FPH,
 };
 
+static const struct {
+	const char *api_version;
+	enum oauth_authz authz;
+	enum mtd_api_scope scope;
+} api_default_values[] = {
+	[EP_API_BD] = {
+		.api_version	= "1.0",
+		.authz		= AUTHZ_USER,
+		.scope		= MTD_API_SCOPE_ITSA,
+	},
+	[EP_API_BSAS] = {
+		.api_version	= "6.0",
+		.authz		= AUTHZ_USER,
+		.scope		= MTD_API_SCOPE_ITSA,
+	},
+	[EP_API_ICAL] = {
+		.api_version	= "7.0",
+		.authz		= AUTHZ_USER,
+		.scope		= MTD_API_SCOPE_ITSA,
+	},
+	[EP_API_ILOS] = {
+		.api_version	= "5.0",
+		.authz		= AUTHZ_USER,
+		.scope		= MTD_API_SCOPE_ITSA,
+	},
+	[EP_API_ISI] = {
+		.api_version	= "1.0",
+		.authz		= AUTHZ_USER,
+		.scope		= MTD_API_SCOPE_ITSA,
+	},
+	[EP_API_OB] = {
+		.api_version	= "3.0",
+		.authz		= AUTHZ_USER,
+		.scope		= MTD_API_SCOPE_ITSA,
+	},
+	[EP_API_PB] = {
+		.api_version	= "5.0",
+		.authz		= AUTHZ_USER,
+		.scope		= MTD_API_SCOPE_ITSA,
+	},
+	[EP_API_SEB] = {
+		.api_version	= "4.0",
+		.authz		= AUTHZ_USER,
+		.scope		= MTD_API_SCOPE_ITSA,
+	},
+
+	[EP_API_TEST_CU] = {
+		.api_version	= "1.0",
+		.authz		= AUTHZ_APPLICATION,
+		.scope		= MTD_API_SCOPE_NULL,
+	},
+	[EP_API_TEST_FPH] = {
+		.api_version	= "1.0",
+		.authz		= AUTHZ_APPLICATION,
+		.scope		= MTD_API_SCOPE_NULL,
+	}
+};
+
 /*
  * The order of these entries must match the order in the
  * mtd_api_endpoint enum in include/libmtdac/mtd.h
@@ -44,96 +103,74 @@ static const struct {
 	const char *tmpl;
 	enum http_method method;
 	enum content_type ctype;
-	enum oauth_authz authz;
 	enum ep_api api;
+	enum oauth_authz authz;
 	enum mtd_api_scope scope;
 } endpoints[] = {
 	/* Business Details */
 	[MTD_API_EP_BD_LIST] = {
 		.tmpl	= "/individuals/business/details/{nino}/list",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_BD,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_BD_GET] = {
 		.tmpl	= "/individuals/business/details/{nino}/{businessId}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_BD,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_BD_AMEND_QPT] = {
 		.tmpl	= "/individuals/business/details/{nino}/{businessId}/{taxYear}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_BD,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 
 	/* Business Source Adjustable Summary */
 	[MTD_API_EP_BSAS_LIST] = {
 		.tmpl	= "/individuals/self-assessment/adjustable-summary/{nino}/{taxYear}/{query_params}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_BSAS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_BSAS_TRIGGER] = {
 		.tmpl	= "/individuals/self-assessment/adjustable-summary/{nino}/trigger",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_BSAS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Business Source Adjustable Summary - Self-Employment */
 	[MTD_API_EP_BSAS_SE_GET] = {
 		.tmpl	= "/individuals/self-assessment/adjustable-summary/{nino}/self-employment/{calculationId}/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_BSAS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_BSAS_SE_SUBMIT] = {
 		.tmpl	= "/individuals/self-assessment/adjustable-summary/{nino}/self-employment/{calculationId}/adjust/{taxYear}",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_BSAS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* UK Property */
 	[MTD_API_EP_BSAS_PB_GET] = {
 		.tmpl	= "/individuals/self-assessment/adjustable-summary/{nino}/uk-property/{calculationId}/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_BSAS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_BSAS_PB_SUBMIT] = {
 		.tmpl	= "/individuals/self-assessment/adjustable-summary/{nino}/uk-property/{calculationId}/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_BSAS,
-		.scope	= MTD_API_SCOPE_ITSA,
 	},
 	/* Foreign Property */
 	[MTD_API_EP_BSAS_FP_GET] = {
 		.tmpl	= "/individuals/self-assessment/adjustable-summary/{nino}/foreign-property/{calculationId}/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_BSAS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_BSAS_FP_SUBMIT] = {
 		.tmpl	= "/individuals/self-assessment/adjustable-summary/{nino}/foreign-property/{calculationId}/adjust/{taxYear}",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_BSAS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 
 	/* Individual Calculations - Tax Calculations */
@@ -141,39 +178,29 @@ static const struct {
 		.tmpl	= "/individuals/calculations/{nino}/self-assessment/{taxYear}/trigger/{calculationType}",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_NONE,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ICAL,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ICAL_LIST_OLD] = {
 		.tmpl	= "/individuals/calculations/{nino}/self-assessment/{query_params}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ICAL,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ICAL_LIST] = {
 		.tmpl	= "/individuals/calculations/{nino}/self-assessment/{taxYear}/{optional_query_params}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ICAL,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ICAL_GET] = {
 		.tmpl	= "/individuals/calculations/{nino}/self-assessment/{taxYear}/{calculationId}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ICAL,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Final Declaration */
 	[MTD_API_EP_ICAL_FINAL_DECLARATION] = {
 		.tmpl	= "/individuals/calculations/{nino}/self-assessment/{taxYear}/{calculationId}/{calculationType}",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_NONE,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ICAL,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 
 	/* Individual Losses - Brought Forward */
@@ -181,399 +208,297 @@ static const struct {
 		.tmpl	= "/individuals/losses/{nino}/brought-forward-losses",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ILOS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ILOS_BF_AMEND_AMNT] = {
 		.tmpl	= "/individuals/losses/{nino}/brought-forward-losses/{lossId}/change-loss-amount",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ILOS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ILOS_BF_LIST] = {
 		.tmpl	= "/individuals/losses/{nino}/brought-forward-losses/tax-year/{taxYearBroughtForwardFrom}/{query_params}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ILOS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ILOS_BF_GET] = {
 		.tmpl	= "/individuals/losses/{nino}/brought-forward-losses/{lossId}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ILOS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ILOS_BF_DELETE] = {
 		.tmpl	= "/individuals/losses/{nino}/brought-forward-losses/{lossId}",
 		.method	= M_DELETE,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ILOS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Loss Claims */
 	[MTD_API_EP_ILOS_LC_CREATE] = {
 		.tmpl	= "/individuals/losses/{nino}/loss-claims",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ILOS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ILOS_LC_LIST] = {
 		.tmpl	= "/individuals/losses/{nino}/loss-claims/tax-year/{taxYearClaimedFor}/{query_params}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ILOS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ILOS_LC_GET] = {
 		.tmpl	= "/individuals/losses/{nino}/loss-claims/{claimId}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ILOS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ILOS_LC_DELETE] = {
 		.tmpl	= "/individuals/losses/{nino}/loss-claims/{claimId}",
 		.method	= M_DELETE,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ILOS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ILOS_LC_AMEND_TYPE] = {
 		.tmpl	= "https://test-api.service.hmrc.gov.uk/individuals/losses/{nino}/loss-claims/{claimId}/change-type-of-claim",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ILOS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ILOS_LC_AMEND_ORDER] = {
 		.tmpl	= "https://test-api.service.hmrc.gov.uk/individuals/losses/{nino}/loss-claims/order/{taxYearClaimedFor}",
 		.method	= M_PUT,
 		.ctype  = CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ILOS,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 
 	/* Individuals Savings Income - UK Savings Account */
 	[MTD_API_EP_ISI_SI_UK_LIST] = {
 		.tmpl	= "/individuals/savings-income/uk-accounts/{nino}/{optional_query_params}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ISI,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ISI_SI_UK_ADD] = {
 		.tmpl	= "/individuals/savings-income/uk-accounts/{nino}",
 		.method	= M_POST,
 		.ctype  = CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ISI,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ISI_SI_UK_GET] = {
 		.tmpl	= "/individuals/savings-income/uk-accounts/{nino}/{taxYear}/{savingsAccountId}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ISI,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ISI_SI_UK_UPDATE] = {
 		.tmpl	= "/individuals/savings-income/uk-accounts/{nino}/{taxYear}/{savingsAccountId}",
 		.method	= M_PUT,
 		.ctype  = CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ISI,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Savings Income */
 	[MTD_API_EP_ISI_SI_O_GET] = {
 		.tmpl	= "/individuals/savings-income/other/{nino}/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ISI,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ISI_SI_O_UPDATE] = {
 		.tmpl	= "/individuals/savings-income/other/{nino}/{taxYear}",
 		.method	= M_PUT,
 		.ctype  = CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ISI,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_ISI_SI_O_DELETE] = {
 		.tmpl	= "/individuals/savings-income/other/{nino}/{taxYear}",
 		.method = M_DELETE,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_ISI,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 
 	/* Obligations */
 	[MTD_API_EP_OB_GET_IEO] = {
 		.tmpl	= "/obligations/details/{nino}/income-and-expenditure/{query_params}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_OB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_OB_GET_FDO] = {
 		.tmpl	= "/obligations/details/{nino}/crystallisation}/{query_params}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_OB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_OB_GET_EPSO] = {
 		.tmpl	= "/obligations/details/{nino}/end-of-period-statement/{query_params}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_OB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 
 	/* Property Business - UK Property Business Annual Submission */
 	[MTD_API_EP_PB_UKPBAS_GET] = {
 		.tmpl	= "/individuals/business/property/uk/{nino}/{businessId}/annual/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_UKPBAS_CREATE] = {
 		.tmpl	= "/individuals/business/property/uk/{nino}/{businessId}/annual/{taxYear}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* UK Property Income & Expenses Period Summary */
 	[MTD_API_EP_PB_UKPIEPS_CREATE] = {
 		.tmpl	= "/individuals/business/property/uk/{nino}/{businessId}/period/{taxYear}",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_UKPIEPS_GET] = {
 		.tmpl	= "/individuals/business/property/uk/{nino}/{businessId}/period/{taxYear}/{submissionId}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_UKPIEPS_AMEND] = {
 		.tmpl	= "/individuals/business/property/uk/{nino}/{businessId}/period/{taxYear}/{submissionId}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* UK Property Cumulative Period Summary */
 	[MTD_API_EP_PB_UKPCPS_GET] = {
 		.tmpl	= "/individuals/business/property/uk/{nino}/{businessId}/cumulative/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_UKPCPS_CREATE] = {
 		.tmpl	= "/individuals/business/property/uk/{nino}/{businessId}/cumulative/{taxYear}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Historic FHL UK Property Business Annual Submission */
 	[MTD_API_EP_PB_HFHL_UKPBAS_CREATE] = {
 		.tmpl	= "/individuals/business/property/uk/annual/furnished-holiday-lettings/{nino}/{taxYear}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_HFHL_UKPBAS_GET] = {
 		.tmpl	= "/individuals/business/property/uk/annual/furnished-holiday-lettings/{nino}/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_HFHL_UKPBAS_DELETE] = {
 		.tmpl	= "/individuals/business/property/uk/annual/furnished-holiday-lettings/{nino}/{taxYear}",
 		.method	= M_DELETE,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Historic non-FHL UK Property Business Annual Submission */
 	[MTD_API_EP_PB_HNFHL_UKPBAS_CREATE] = {
 		.tmpl	= "/individuals/business/property/uk/annual/non-furnished-holiday-lettings/{nino}/{taxYear}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_HNFHL_UKPBAS_GET] = {
 		.tmpl	= "/individuals/business/property/uk/annual/non-furnished-holiday-lettings/{nino}/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_HNFHL_UKPBAS_DELETE] = {
 		.tmpl	= "/individuals/business/property/uk/annual/non-furnished-holiday-lettings/{nino}/{taxYear}",
 		.method	= M_DELETE,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Historic FHL UK Property Income & Expenses Period Summary */
 	[MTD_API_EP_PB_HFHL_UKPIEPS_LIST] = {
 		.tmpl	= "/individuals/business/property/uk/period/furnished-holiday-lettings/{nino}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_HFHL_UKPIEPS_CREATE] = {
 		.tmpl	= "/individuals/business/property/uk/period/furnished-holiday-lettings/{nino}",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_HFHL_UKPIEPS_AMEND] = {
 		.tmpl	= "/individuals/business/property/uk/period/furnished-holiday-lettings/{nino}/{periodId}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_HFHL_UKPIEPS_GET] = {
 		.tmpl	= "/individuals/business/property/uk/period/furnished-holiday-lettings/{nino}/{periodId}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Historic non-FHL UK Property Income & Expenses Period Summary */
 	[MTD_API_EP_PB_HNFHL_UKPIEPS_LIST] = {
 		.tmpl	= "/individuals/business/property/uk/period/non-furnished-holiday-lettings/{nino}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_HNFHL_UKPIEPS_CREATE] = {
 		.tmpl	= "/individuals/business/property/uk/period/non-furnished-holiday-lettings/{nino}",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_HNFHL_UKPIEPS_GET] = {
 		.tmpl	= "/individuals/business/property/uk/period/non-furnished-holiday-lettings/{nino}/{periodId}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_HNFHL_UKPIEPS_AMEND] = {
 		.tmpl	= "/individuals/business/property/uk/period/non-furnished-holiday-lettings/{nino}/{periodId}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Foreign Property Income & Expenses Period Summary */
 	[MTD_API_EP_PB_FPIEPS_CREATE] = {
 		.tmpl	= "/individuals/business/property/foreign/{nino}/{businessId}/period/{taxYear}",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_FPIEPS_GET] = {
 		.tmpl	= "/individuals/business/property/foreign/{nino}/{businessId}/period/{taxYear}/{submissionId}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_FPIEPS_AMEND] = {
 		.tmpl	= "/individuals/business/property/foreign/{nino}/{businessId}/period/{taxYear}/{submissionId}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Foreign Property Cumulative Period Summary */
 	[MTD_API_EP_PB_FPCPS_GET] = {
 		.tmpl	= "/individuals/business/property/foreign/{nino}/{businessId}/cumulative/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_FPCPS_AMEND] = {
 		.tmpl	= "/individuals/business/property/foreign/{nino}/{businessId}/cumulative/{taxYear}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Foreign Property Annual Submission */
 	[MTD_API_EP_PB_FPAS_GET] = {
 		.tmpl	= "/individuals/business/property/foreign/{nino}/{businessId}/annual/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_PB_FPAS_AMEND] = {
 		.tmpl	= "/individuals/business/property/foreign/{nino}/{businessId}/annual/{taxYear}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* UK or Foreign Property Annual Submission Deletion */
 	[MTD_API_EP_PB_AS_DELETE] = {
 		.tmpl	= "/individuals/business/property/{nino}/{businessId}/annual/{taxYear}",
 		.method	= M_DELETE,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* UK or Foreign Property Income and Expenses Period Summaries List */
 	[MTD_API_EP_PB_PIEPS_LIST] = {
 		.tmpl	= "/individuals/business/property/{nino}/{businessId}/period/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_PB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 
 	/* Self Employment Business - Self-Employment Annual Submission */
@@ -581,70 +506,52 @@ static const struct {
 		.tmpl	= "/individuals/business/self-employment/{nino}/{businessId}/annual/{taxYear}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_SEB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_SEB_SEAS_GET] = {
 		.tmpl	= "/individuals/business/self-employment/{nino}/{businessId}/annual/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_SEB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_SEB_SEAS_DELETE] = {
 		.tmpl	= "/individuals/business/self-employment/{nino}/{businessId}/annual/{taxYear}",
 		.method	= M_DELETE,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_SEB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Self-Employment Period Summaries */
 	[MTD_API_EP_SEB_SEPS_CREATE] = {
 		.tmpl	= "/individuals/business/self-employment/{nino}/{businessId}/period",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_SEB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_SEB_SEPS_LIST] = {
 		.tmpl	= "/individuals/business/self-employment/{nino}/{businessId}/period/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_SEB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_SEB_SEPS_AMEND] = {
 		.tmpl	= "/individuals/business/self-employment/{nino}/{businessId}/period/{taxYear}/{periodId}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_SEB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_SEB_SEPS_GET] = {
 		.tmpl	= "/individuals/business/self-employment/{nino}/{businessId}/period/{taxYear}/{periodId}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_SEB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	/* Self-Employment Cumulative Period Summary */
 	[MTD_API_EP_SEB_SECPS_AMEND] = {
 		.tmpl	= "/individuals/business/self-employment/{nino}/{businessId}/cumulative/{taxYear}",
 		.method	= M_PUT,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_SEB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 	[MTD_API_EP_SEB_SECPS_GET] = {
 		.tmpl	= "/individuals/business/self-employment/{nino}/{businessId}/cumulative/{taxYear}",
 		.method	= M_GET,
-		.authz	= AUTHZ_USER,
 		.api	= EP_API_SEB,
-		.scope	= MTD_API_SCOPE_ITSA
 	},
 
 
@@ -653,48 +560,36 @@ static const struct {
 		.tmpl	= "/create-test-user/individuals",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_APPLICATION,
 		.api	= EP_API_TEST_CU,
-		.scope	= MTD_API_SCOPE_NULL
 	},
 	[MTD_API_EP_TEST_CU_CREATE_ORGANISATION] = {
 		.tmpl	= "/create-test-user/organisations",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_APPLICATION,
 		.api	= EP_API_TEST_CU,
-		.scope	= MTD_API_SCOPE_NULL
 	},
 	[MTD_API_EP_TEST_CU_CREATE_AGENT] = {
 		.tmpl	= "/create-test-user/agents",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_JSON,
-		.authz	= AUTHZ_APPLICATION,
 		.api	= EP_API_TEST_CU,
-		.scope	= MTD_API_SCOPE_NULL
 	},
 	[MTD_API_EP_TEST_CU_LIST_SERVICES] = {
 		.tmpl	= "/create-test-user/services",
 		.method	= M_GET,
-		.authz	= AUTHZ_APPLICATION,
 		.api	= EP_API_TEST_CU,
-		.scope	= MTD_API_SCOPE_NULL
 	},
 
 	/* Test Fraud Prevention Headers */
 	[MTD_API_EP_TEST_FPH_VALIDATE] = {
 		.tmpl	= "/test/fraud-prevention-headers/validate",
 		.method	= M_GET,
-		.authz	= AUTHZ_APPLICATION,
 		.api	= EP_API_TEST_FPH,
-		.scope	= MTD_API_SCOPE_NULL
 	},
 	[MTD_API_EP_TEST_FPH_FEEDBACK] = {
 		.tmpl	= "/test/fraud-prevention-headers/{api}/validation-feedback/{query_params}",
 		.method	= M_GET,
-		.authz	= AUTHZ_APPLICATION,
 		.api	= EP_API_TEST_FPH,
-		.scope	= MTD_API_SCOPE_NULL
 	},
 
 	/* OAuth */
@@ -702,24 +597,24 @@ static const struct {
 		.tmpl	= "/oauth/token",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_URL_ENCODED,
-		.authz	= AUTHZ_NONE,
 		.api	= EP_API_NULL,
+		.authz	= AUTHZ_NONE,
 		.scope	= MTD_API_SCOPE_NULL
 	},
 	[MTD_API_EP_OA_EXCHANGE_AUTH_CODE] = {
 		.tmpl	= "/oauth/token",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_URL_ENCODED,
-		.authz	= AUTHZ_NONE,
 		.api	= EP_API_NULL,
+		.authz	= AUTHZ_NONE,
 		.scope	= MTD_API_SCOPE_NULL
 	},
 	[MTD_API_EP_OA_APPLICATION_TOKEN] = {
 		.tmpl	= "/oauth/token",
 		.method	= M_POST,
 		.ctype	= CONTENT_TYPE_URL_ENCODED,
-		.authz	= AUTHZ_NONE,
 		.api	= EP_API_NULL,
+		.authz	= AUTHZ_NONE,
 		.scope	= MTD_API_SCOPE_NULL
 	},
 };

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -17,6 +17,7 @@ static const struct {
 	const char *name;
 	const char *fname;
 } api_scope_map[] = {
+	[MTD_API_SCOPE_UNSET]	= {},
 	[MTD_API_SCOPE_ITSA]	= { "itsa", "Income Tax Self-Assessment" },
 	[MTD_API_SCOPE_VAT]	= { "vat", "VAT"			 },
 };


### PR DESCRIPTION
Most of the API endpoints have the same .authz and .scope values.

Extend and rename the api_version_map[] array to now be a set of default values for an endpoint API. Move it into api_endpoints.h where it's better suited and we can then create a couple of inline helper functions for getting the right .authz and .scope values.

We check the endpoints array first for the .authz and .scope values, if they aren't set we grab one or both values from this new array.

This allows to remove most of the .authz and .scope initialisers from endpoints[]. We leave the OAuth entries as they are slightly different.