### PR TITLE
endpoints: Rename a couple of MTD_API_EP_ISI_SI_UK_ endpoints

### DIFF
--- a/include/libmtdac/mtd.h
+++ b/include/libmtdac/mtd.h
@@ -287,8 +287,8 @@ enum mtd_api_endpoint {
 	/* Individuals Savings Income - UK Savings Account */
 	MTD_API_EP_ISI_SI_UK_LIST,
 	MTD_API_EP_ISI_SI_UK_ADD,
-	MTD_API_EP_ISI_SI_UK_GET,
-	MTD_API_EP_ISI_SI_UK_UPDATE,
+	MTD_API_EP_ISI_SI_UK_GET_AS,
+	MTD_API_EP_ISI_SI_UK_UPDATE_AS,
 	/* Savings Income */
 	MTD_API_EP_ISI_SI_O_GET,
 	MTD_API_EP_ISI_SI_O_UPDATE,

--- a/src/api_endpoints.h
+++ b/src/api_endpoints.h
@@ -278,12 +278,12 @@ static const struct {
 		.ctype  = CONTENT_TYPE_JSON,
 		.api	= EP_API_ISI,
 	},
-	[MTD_API_EP_ISI_SI_UK_GET] = {
+	[MTD_API_EP_ISI_SI_UK_GET_AS] = {
 		.tmpl	= "/individuals/savings-income/uk-accounts/{nino}/{taxYear}/{savingsAccountId}",
 		.method	= M_GET,
 		.api	= EP_API_ISI,
 	},
-	[MTD_API_EP_ISI_SI_UK_UPDATE] = {
+	[MTD_API_EP_ISI_SI_UK_UPDATE_AS] = {
 		.tmpl	= "/individuals/savings-income/uk-accounts/{nino}/{taxYear}/{savingsAccountId}",
 		.method	= M_PUT,
 		.ctype  = CONTENT_TYPE_JSON,


### PR DESCRIPTION
Rename the MTD_API_EP_ISI_SI_UK_GET & MTD_API_EP_ISI_SI_UK_UPDATE endpoints to append _AS to them to signify "Annual Summary".