### PR TITLE
docs: Don't 'clean' the man-pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ tags:
 
 .PHONY: clean
 clean:
-	@echo "Cleaning: libmtdac man"
+	@echo "Cleaning: libmtdac"
 	@$(MAKE) $(MAKE_OPTS) -C src/ clean
-	@$(MAKE) $(MAKE_OPTS) -C docs/ clean
 	@rm -f .version

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -28,7 +28,3 @@ $(MANS3)/%.3: %.3.rst
 $(MANS3type)/%.3type: %.3type.rst
 	@echo "  MAN   $@"
 	$(v)$(PANDOC3type) --metadata date="$(DATE)" -o $@
-
-.PHONY: clean
-clean:
-	$(v)rm -f $(MANS3)/*.3 $(MANS3type)/*.3type


### PR DESCRIPTION
Remove the docs 'clean' make target so as not to remove the man-pages. Even though they are auto-generated from the .rst's, they are still under version control and we don't want them always being updated (even if it's just the date) if there wasn't any actual changes.