### PR TITLE
Share version information between the Makefiles

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,6 @@
-VERSION	    = 1.0.0
+include ../version.mk
+
+VERSION	    = $(MAJOR).$(MINOR).$(PATCH)
 DATE	    = $(shell date +"%b %e, %Y")
 
 MANS3	    = man/man3

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,9 +1,11 @@
+include ../version.mk
+
 LIBNAME = libmtdac
 
 GIT_VERSION  = \"$(shell git describe --long --dirty 2> /dev/null || cat ../.version)\"
 
-SOVER	= 1
-VERSION = $(SOVER).0.0
+SOVER	= $(MAJOR)
+VERSION = $(MAJOR).$(MINOR).$(PATCH)
 
 OBJ_DIR := .objs
 $(shell mkdir -p $(OBJ_DIR) >/dev/null)

--- a/version.mk
+++ b/version.mk
@@ -1,0 +1,3 @@
+MAJOR	= 1
+MINOR	= 0
+PATCH	= 0


### PR DESCRIPTION
Factor the version out into a version.mk file that is then included in {docs,src}/Makefile.