### PR TITLE
Linkify a couple of documents

### DIFF
--- a/Contributing.rst
+++ b/Contributing.rst
@@ -11,7 +11,7 @@ with signed-off commits. This means adding a line that says
  Signed-off-by: Andrew Clayton <ac@sigsegv.uk>
 
 This signifies that you have read/understood/and agreed to the
-[Developer's Certificate of Origin](DCO). Essentially indicating that you
+`Developer’s Certificate of Origin <DCO>`__. Essentially indicating that you
 wrote the code and/or have the right to contribute it to this project.
 
 This is **not** a CLA.

--- a/README.rst
+++ b/README.rst
@@ -206,7 +206,7 @@ License
 This library is licensed under the GNU Lesser General Public License
 (LGPL) version 2.1
 
-See *COPYING* in the repository root for details.
+See `COPYING </COPYING>`__ in the repository root for details.
 
 Contributing
 ------------


### PR DESCRIPTION
Make the DCO link work (it was still in markdown link format) and make a link to COPYING.