### PR TITLE
Scopes

### DIFF
--- a/docs/libmtdac_mtd.h.3.rst
+++ b/docs/libmtdac_mtd.h.3.rst
@@ -306,7 +306,7 @@ authorised for.
   enum mtd_api_scope {
           MTD_API_SCOPE_UNSET             = 0x0,
 
-          MTD_API_SCOPE_ITSA              = 0x1,
+          MTD_API_SCOPE_SA                = 0x1,
           MTD_API_SCOPE_VAT               = 0x2,
 
           /*
@@ -317,6 +317,7 @@ authorised for.
            */
           MTD_API_SCOPE_ADD               = (1 << 29),
   };
+  #define MTD_API_SCOPE_ITSA MTD_API_SCOPE_SA
 
 What API the above scopes belong to. They can be OR'd together.
 *MTD_API_SCOPE_ADD* can be used to avoid resetting the oauth.json file

--- a/docs/libmtdac_mtd.h.3.rst
+++ b/docs/libmtdac_mtd.h.3.rst
@@ -291,12 +291,14 @@ OAuth Scopes
   enum mtd_scope {
           MTD_SCOPE_RD_SA         = 0x1,
           MTD_SCOPE_WR_SA         = 0x2,
-          MTD_SCOPE_RD_VAT        = 0x4,
-          MTD_SCOPE_WR_VAT        = 0x8,
+          MTD_SCOPE_RD_SAASS      = 0x4,
+          MTD_SCOPE_WR_SAASS      = 0x8,
+          MTD_SCOPE_RD_VAT        = 0x10,
+          MTD_SCOPE_WR_VAT        = 0x20,
   };
 
-RD = Read, WR = write, SA = Self-Assessment (ITSA). They can ibe OR'd
-together.
+RD = Read, WR = write, SA = Self-Assessment (ITSA). SAASS Self-Assessment
+Assist (ITSA). They can be OR'd together.
 
 They represent the various OAuth scopes that an application can be
 authorised for.
@@ -307,7 +309,8 @@ authorised for.
           MTD_API_SCOPE_UNSET             = 0x0,
 
           MTD_API_SCOPE_SA                = 0x1,
-          MTD_API_SCOPE_VAT               = 0x2,
+          MTD_API_SCOPE_SAASS             = 0x2,
+          MTD_API_SCOPE_VAT               = 0x4,
 
           /*
            * Special value to tell we are adding more API
@@ -321,8 +324,8 @@ authorised for.
 
 What API the above scopes belong to. They can be OR'd together.
 *MTD_API_SCOPE_ADD* can be used to avoid resetting the oauth.json file
-when writing to it. Say you added ITSA bu then later want to also add
-VAT...
+when writing to it. Say you added SA but then later want to also add
+SAASS...
 
 MTD API Endpoints
 -----------------

--- a/docs/man/man3/libmtdac_mtd.h.3
+++ b/docs/man/man3/libmtdac_mtd.h.3
@@ -281,7 +281,7 @@ authorised for.
 enum mtd_api_scope {
         MTD_API_SCOPE_UNSET             = 0x0,
 
-        MTD_API_SCOPE_ITSA              = 0x1,
+        MTD_API_SCOPE_SA                = 0x1,
         MTD_API_SCOPE_VAT               = 0x2,
 
         /*
@@ -292,6 +292,7 @@ enum mtd_api_scope {
          */
         MTD_API_SCOPE_ADD               = (1 << 29),
 };
+#define MTD_API_SCOPE_ITSA MTD_API_SCOPE_SA
 .EE
 .PP
 What API the above scopes belong to.

--- a/docs/man/man3/libmtdac_mtd.h.3
+++ b/docs/man/man3/libmtdac_mtd.h.3
@@ -266,13 +266,16 @@ enum mtd_http_status_code {
 enum mtd_scope {
         MTD_SCOPE_RD_SA         = 0x1,
         MTD_SCOPE_WR_SA         = 0x2,
-        MTD_SCOPE_RD_VAT        = 0x4,
-        MTD_SCOPE_WR_VAT        = 0x8,
+        MTD_SCOPE_RD_SAASS      = 0x4,
+        MTD_SCOPE_WR_SAASS      = 0x8,
+        MTD_SCOPE_RD_VAT        = 0x10,
+        MTD_SCOPE_WR_VAT        = 0x20,
 };
 .EE
 .PP
 RD = Read, WR = write, SA = Self\-Assessment (ITSA).
-They can ibe OR\[aq]d together.
+SAASS Self\-Assessment Assist (ITSA).
+They can be OR\[aq]d together.
 .PP
 They represent the various OAuth scopes that an application can be
 authorised for.
@@ -282,7 +285,8 @@ enum mtd_api_scope {
         MTD_API_SCOPE_UNSET             = 0x0,
 
         MTD_API_SCOPE_SA                = 0x1,
-        MTD_API_SCOPE_VAT               = 0x2,
+        MTD_API_SCOPE_SAASS             = 0x2,
+        MTD_API_SCOPE_VAT               = 0x4,
 
         /*
          * Special value to tell we are adding more API
@@ -299,7 +303,7 @@ What API the above scopes belong to.
 They can be OR\[aq]d together.
 \f[I]MTD_API_SCOPE_ADD\f[R] can be used to avoid resetting the
 oauth.json file when writing to it.
-Say you added ITSA bu then later want to also add VAT...
+Say you added SA but then later want to also add SAASS...
 .SS MTD API Endpoints
 .IP
 .EX

--- a/include/libmtdac/mtd.h
+++ b/include/libmtdac/mtd.h
@@ -259,7 +259,7 @@ enum mtd_scope {
 enum mtd_api_scope {
 	MTD_API_SCOPE_UNSET		= 0x0,
 
-	MTD_API_SCOPE_ITSA		= 0x1,
+	MTD_API_SCOPE_SA		= 0x1,
 	MTD_API_SCOPE_VAT		= 0x2,
 
 	/*
@@ -273,6 +273,8 @@ enum mtd_api_scope {
 	/* Only used internally */
 	MTD_API_SCOPE_NULL		= (1 << 30)
 };
+/* Compat */
+#define MTD_API_SCOPE_ITSA MTD_API_SCOPE_SA
 
 /*
  * The order of these entries must match the order in endpoints[]

--- a/include/libmtdac/mtd.h
+++ b/include/libmtdac/mtd.h
@@ -252,15 +252,18 @@ enum mtd_http_status_code {
 enum mtd_scope {
 	MTD_SCOPE_RD_SA		= 0x1,
 	MTD_SCOPE_WR_SA		= 0x2,
-	MTD_SCOPE_RD_VAT	= 0x4,
-	MTD_SCOPE_WR_VAT	= 0x8,
+	MTD_SCOPE_RD_SAASS	= 0x4,
+	MTD_SCOPE_WR_SAASS	= 0x8,
+	MTD_SCOPE_RD_VAT	= 0x10,
+	MTD_SCOPE_WR_VAT	= 0x20,
 };
 
 enum mtd_api_scope {
 	MTD_API_SCOPE_UNSET		= 0x0,
 
 	MTD_API_SCOPE_SA		= 0x1,
-	MTD_API_SCOPE_VAT		= 0x2,
+	MTD_API_SCOPE_SAASS		= 0x2,
+	MTD_API_SCOPE_VAT		= 0x4,
 
 	/*
 	 * Special value to tell we are adding more API

--- a/src/api_endpoints.h
+++ b/src/api_endpoints.h
@@ -50,57 +50,57 @@ static const struct {
 	[EP_API_BD] = {
 		.api_version	= "1.0",
 		.authz		= AUTHZ_USER,
-		.scope		= MTD_API_SCOPE_ITSA,
+		.scope		= MTD_API_SCOPE_SA,
 	},
 	[EP_API_BISS] = {
 		.api_version	= "3.0",
 		.authz		= AUTHZ_USER,
-		.scope		= MTD_API_SCOPE_ITSA,
+		.scope		= MTD_API_SCOPE_SA,
 	},
 	[EP_API_BSAS] = {
 		.api_version	= "6.0",
 		.authz		= AUTHZ_USER,
-		.scope		= MTD_API_SCOPE_ITSA,
+		.scope		= MTD_API_SCOPE_SA,
 	},
 	[EP_API_ICAL] = {
 		.api_version	= "7.0",
 		.authz		= AUTHZ_USER,
-		.scope		= MTD_API_SCOPE_ITSA,
+		.scope		= MTD_API_SCOPE_SA,
 	},
 	[EP_API_ILOS] = {
 		.api_version	= "5.0",
 		.authz		= AUTHZ_USER,
-		.scope		= MTD_API_SCOPE_ITSA,
+		.scope		= MTD_API_SCOPE_SA,
 	},
 	[EP_API_IPI] = {
 		.api_version	= "1.0",
 		.authz		= AUTHZ_USER,
-		.scope		= MTD_API_SCOPE_ITSA,
+		.scope		= MTD_API_SCOPE_SA,
 	},
 	[EP_API_ISI] = {
 		.api_version	= "1.0",
 		.authz		= AUTHZ_USER,
-		.scope		= MTD_API_SCOPE_ITSA,
+		.scope		= MTD_API_SCOPE_SA,
 	},
 	[EP_API_OB] = {
 		.api_version	= "3.0",
 		.authz		= AUTHZ_USER,
-		.scope		= MTD_API_SCOPE_ITSA,
+		.scope		= MTD_API_SCOPE_SA,
 	},
 	[EP_API_PB] = {
 		.api_version	= "5.0",
 		.authz		= AUTHZ_USER,
-		.scope		= MTD_API_SCOPE_ITSA,
+		.scope		= MTD_API_SCOPE_SA,
 	},
 	[EP_API_SAID] = {
 		.api_version	= "2.0",
 		.authz		= AUTHZ_USER,
-		.scope		= MTD_API_SCOPE_ITSA,
+		.scope		= MTD_API_SCOPE_SA,
 	},
 	[EP_API_SEB] = {
 		.api_version	= "4.0",
 		.authz		= AUTHZ_USER,
-		.scope		= MTD_API_SCOPE_ITSA,
+		.scope		= MTD_API_SCOPE_SA,
 	},
 
 	[EP_API_VAT] = {

--- a/src/auth.c
+++ b/src/auth.c
@@ -79,7 +79,7 @@ char *load_token(const char *which, enum file_type ft, enum mtd_api_scope scope)
 		 * APIs under both sets of credentials.
 		 */
 		tok_obj = json_object_get(root,
-					  api_scope_map[MTD_API_SCOPE_ITSA].name);
+					  api_scope_map[MTD_API_SCOPE_SA].name);
 		if (!tok_obj)
 			tok_obj = json_object_get(root,
 						  api_scope_map[MTD_API_SCOPE_VAT].name);

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -17,9 +17,20 @@ static const struct {
 	const char *name;
 	const char *fname;
 } api_scope_map[] = {
-	[MTD_API_SCOPE_UNSET]	= {},
-	[MTD_API_SCOPE_SA]	= { "itsa", "Income Tax Self-Assessment" },
-	[MTD_API_SCOPE_VAT]	= { "vat", "VAT"			 },
+	[MTD_API_SCOPE_UNSET] = {
+	},
+	[MTD_API_SCOPE_SA] = {
+		.name	= "itsa",
+		.fname	= "Income Tax Self-Assessment"
+	},
+	[MTD_API_SCOPE_SAASS] = {
+		.name	= "itsa-assist",
+		.fname	= "Income Tax Self-Assessment Assist"
+	},
+	[MTD_API_SCOPE_VAT] = {
+		.name	= "vat",
+		.fname	= "VAT"
+	},
 };
 
 extern int (*ep_set_oauther(enum mtd_api_endpoint ep))(enum mtd_api_scope);

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -18,7 +18,7 @@ static const struct {
 	const char *fname;
 } api_scope_map[] = {
 	[MTD_API_SCOPE_UNSET]	= {},
-	[MTD_API_SCOPE_ITSA]	= { "itsa", "Income Tax Self-Assessment" },
+	[MTD_API_SCOPE_SA]	= { "itsa", "Income Tax Self-Assessment" },
 	[MTD_API_SCOPE_VAT]	= { "vat", "VAT"			 },
 };
 

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -661,7 +661,7 @@ int mtd_init_creds(enum mtd_api_scope scope)
 	scope &= ~MTD_API_SCOPE_ADD;
 
 	switch (scope) {
-	case MTD_API_SCOPE_ITSA:
+	case MTD_API_SCOPE_SA:
 		type_s = "ITSA";
 		break;
 	case MTD_API_SCOPE_VAT:

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -469,6 +469,12 @@ static const struct {
 		.scope	= MTD_SCOPE_WR_SA,
 		.str	= "write:self-assessment"
 	}, {
+		.scope	= MTD_SCOPE_RD_SAASS,
+		.str	= "read:self-assessment-assist"
+	}, {
+		.scope	= MTD_SCOPE_WR_SAASS,
+		.str	= "write:self-assessment-assist",
+	}, {
 		.scope	= MTD_SCOPE_RD_VAT,
 		.str	= "read:vat"
 	}, {
@@ -476,10 +482,10 @@ static const struct {
 		.str	= "write:vat"
 	},
 };
-#define ALL_SCOPES	(MTD_SCOPE_RD_SA|MTD_SCOPE_WR_SA|MTD_SCOPE_RD_VAT| \
-			 MTD_SCOPE_WR_VAT)
-#define RD_SCOPES	(MTD_SCOPE_RD_SA|MTD_SCOPE_RD_VAT)
-#define WR_SCOPES	(MTD_SCOPE_WR_SA|MTD_SCOPE_WR_VAT)
+#define ALL_SCOPES	(MTD_SCOPE_RD_SA|MTD_SCOPE_WR_SA|MTD_SCOPE_RD_SAASS| \
+			 MTD_SCOPE_WR_SAASS|MTD_SCOPE_RD_VAT|MTD_SCOPE_WR_VAT)
+#define RD_SCOPES	(MTD_SCOPE_RD_SA|MTD_SCOPE_RD_SAASS|MTD_SCOPE_RD_VAT)
+#define WR_SCOPES	(MTD_SCOPE_WR_SA|MTD_SCOPE_WR_SAASS|MTD_SCOPE_WR_VAT)
 
 extern char **environ;
 int mtd_init_auth(enum mtd_api_scope scope, unsigned long scopes)
@@ -663,6 +669,9 @@ int mtd_init_creds(enum mtd_api_scope scope)
 	switch (scope) {
 	case MTD_API_SCOPE_SA:
 		type_s = "ITSA";
+		break;
+	case MTD_API_SCOPE_SAASS:
+		type_s = "ITSA Assist";
 		break;
 	case MTD_API_SCOPE_VAT:
 		type_s = "VAT";


### PR DESCRIPTION
* Rename `MTD_API_SCOPE_ITSA` to `MTD_API_SCOPE_SA`, but leave `MTD_API_SCOPE_ITSA` as an alias
* Add a new scope for the Self-Assessment Assist API