### PR TITLE
Support application restricted endpoints with scopes

### DIFF
--- a/src/endpoint.c
+++ b/src/endpoint.c
@@ -93,15 +93,14 @@ int (*ep_set_oauther(enum mtd_api_endpoint ep))(enum mtd_api_scope)
 char *ep_get_token(enum mtd_api_endpoint ep)
 {
 	enum oauth_authz authz = get_authz(ep);
+	enum mtd_api_scope scope = get_scope(ep);
 
 	switch(authz) {
 	case AUTHZ_USER: {
-		enum mtd_api_scope scope = get_scope(ep);
 		return load_token("access_token", FT_AUTH, scope);
 	}
 	case AUTHZ_APPLICATION:
-		return load_token("access_token", FT_AUTH_APPLICATION,
-				  MTD_API_SCOPE_NULL);
+		return load_token("access_token", FT_AUTH_APPLICATION, scope);
 	default:
 		return NULL;
 	}


### PR DESCRIPTION
Up till now application restricted endpoints like the Fraud Prevention Headers test API haven't required any scopes.

However some do, such as the Self Assessment Test Support API. This adds support for such things that require the self-assessment read/write scopes.

If such an endpoint is called it will request an application oauth token with the read:self-assessment+write:self-assessment scopes and store the token in an oauth-application-sa.json file.