### PR TITLE
Flow some extra response headers from HMRC through

### DIFF
--- a/src/curler.h
+++ b/src/curler.h
@@ -45,6 +45,9 @@ struct curl_ctx {
 	const char *url;
 	char *location;
 	char *x_corr_id;
+	char *deprecation_hdr;
+	char *sunset_hdr;
+	char *link_hdr;
 
 	const char *mtd_api_ver;
 


### PR DESCRIPTION
When an API is in the process of being deprecated, HMRC will flow the following response headers through

Deprecation	The deprecation date/time for this endpoint.

Sunset		(optional) The earliest date/time this endpoint will
		become unavailable after deprecation,

Link		Documentation URL for the relevant API.

These will be shown in the main response JSON as either the value as returned by HMRC or 'null' if they are not set.