### PR TITLE
mtd.c: Check for non-directory components in mkdir_p()

### DIFF
--- a/src/mtd.c
+++ b/src/mtd.c
@@ -300,8 +300,15 @@ static int mkdir_p(int dirfd, const char *path, mode_t mode)
 		strcat(mdir, token);
 
 		err = fstatat(dirfd, mdir, &sb, 0);
-		if (!err)
+		if (!err) {
+			if (!S_ISDIR(sb.st_mode)) {
+				errno = ENOTDIR;
+				ret = -1;
+				break;
+			}
+
 			goto next_component;
+		}
 
 		err = mkdirat(dirfd, mdir, mode);
 		if (err == -1 && errno != EEXIST) {


### PR DESCRIPTION
Check the result of the fstatat(2) to see if we got a non-directory path component.

This would really only be a problem if the *last* component wasn't a directory as otherwise the mkdirat(2) will catch it.