### PR TITLE
curler: Fix POST requests with no body

### DIFF
--- a/src/curler.c
+++ b/src/curler.c
@@ -420,6 +420,12 @@ static int set_headers(struct curl_ctx *ctx)
 	case CONTENT_TYPE_JSON:
 		err = curl_add_hdr(ctx, "Content-Type: application/json");
 		break;
+	case CONTENT_TYPE_NONE:
+		err = curl_add_hdr(ctx, "Content-Length:");
+		if (err)
+			break;
+		err = curl_add_hdr(ctx, "Content-Type:");
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
Some API endpoints use a POST request without a body. Previously we were sending these with the following headers

  Content-Length: 0
  Content-Type: application/x-www-form-urlencoded

However it seems these now result in a 500 Internal Server Error.

To make MTD happy it seems we need to *not* send these headers for empty POST requests.