### PR TITLE
endpoint: Better handle missing parameters in ep_make_url()

### DIFF
--- a/src/endpoint.c
+++ b/src/endpoint.c
@@ -165,9 +165,12 @@ char *ep_make_url(enum mtd_api_endpoint ep, const char * const params[],
 		else if (strstr(token, "query_params"))
 			snprintf(url + len, URL_LEN+1 - len, "%s",
 				 params && params[p] ? params[p++] : "");
-		else
+		else if (params && params[p])
 			snprintf(url + len, URL_LEN+1 - len, "/%s",
 				 params[p++]);
+		else
+			/* This will show what parameter(s) are missing */
+			snprintf(url + len, URL_LEN+1 - len, "/%s", token);
 
 		len = strlen(url);
 	}


### PR DESCRIPTION
Add a params check before attempting to use it when adding a parameter that isn't nino or a query string.

If we don't have any parameters left in the array, just create an invalid URL with the name(s) of the missing parameter(s) then let the subsequent errors flow through to the client. They will then see exactly what is missing.