### PR TITLE
mtd: Fix percent encoding of characters > 127

### DIFF
--- a/src/mtd.c
+++ b/src/mtd.c
@@ -197,7 +197,7 @@ char *mtd_percent_encode(const char *str, size_t len)
 	p = buf;
 
 	for (size_t i = 0; i < len; i++) {
-		char ch = str[i];
+		unsigned char ch = str[i];
 
 		switch (ch) {
 		case 'A' ... 'Z':


### PR DESCRIPTION
Use an unsigned char for the variable passed to the printf(3) as the 'X' format specifier expects an unsigned int.

This fixes for example the encoding of '£'. %C2%A3 instead of %FFFFFFC2%FFFFFFA3.