### PR TITLE
Update the SONAME to be MAJOR.MINOR

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,8 +4,8 @@ LIBNAME = libmtdac
 
 GIT_VERSION  = \"$(shell git describe --long --dirty 2> /dev/null || cat ../.version)\"
 
-SOVER	= $(MAJOR)
-VERSION = $(MAJOR).$(MINOR).$(PATCH)$(PLUS)
+SOVER	= $(MAJOR).$(MINOR)
+VERSION = $(SOVER).$(PATCH)$(PLUS)
 
 OBJ_DIR := .objs
 $(shell mkdir -p $(OBJ_DIR) >/dev/null)


### PR DESCRIPTION
Currently I quite often make changes that break ABI, such as updating enums in the middle.

But rather than continuously bumping the MAJOR version, I'd rather just bump the MINOR.